### PR TITLE
Fixed when LoadPage returns an empty array

### DIFF
--- a/UserVoice/Collection.cs
+++ b/UserVoice/Collection.cs
@@ -24,8 +24,9 @@ namespace UserVoice
         }
         public int Count {
             get {
-                if (this.responseData == null && this[0] != null) {
-                    /* Avoiding warning with overloaded this[int] */
+                if (this.responseData == null) {
+                    //Load the first page
+                    LoadPage(1);
                 }
                 return Math.Min((int)this.responseData["total_records"], this.limit);
             }


### PR DESCRIPTION
When the LoadPage is called by the Count property, which happens via the
this[0] invocation,
and the LoadPage  returns an empy JToken[], we were getting an
exception, since the indexer (this[i]) method doesn't check if it is an
empty array.

Here is the typical consumer code

var client = new UserCoice.Client(subdomain, key, secret);
client.LoginAsOwner();
var result = client.GetCollection(pathToCollection);
Console.WriteLine("Num of Items: " + result.Count);

If it is an empty collection, without this fix, we get an index out of
range exception.

Here is a json response that will cause the exception

{"response_data":{"page":1,"per_page":100,"total_records":0,"filter":"all","sort":"newest"},
"manual_actions":[]}

This is a real example, obtained using the manual_actions method (GET
/api/v1/manual_actions)
