### PR TITLE
Proxy Awareness

### DIFF
--- a/UserVoice/Client.cs
+++ b/UserVoice/Client.cs
@@ -32,7 +32,7 @@ namespace UserVoice
         public string Secret;
         private Client requestToken = null;
 
-        public Client(string subdomainName, string apiKey, string apiSecret=null, string callback=null, string token=null, string secret=null, string uservoiceDomain=null, string protocol=null) {
+        public Client(string subdomainName, string apiKey, string apiSecret=null, string callback=null, string token=null, string secret=null, string uservoiceDomain=null, string protocol=null, IWebProxy proxy = null) {
             this.protocol = protocol ?? "https";
             this.uservoiceDomain = uservoiceDomain ?? "uservoice.com";
             this.apiKey = apiKey;
@@ -44,10 +44,12 @@ namespace UserVoice
             consumer = new RestClient(this.protocol + "://" + this.subdomainName + "." + this.uservoiceDomain);
             if (apiSecret != null) {
                 consumer.Authenticator = OAuth1Authenticator.ForRequestToken(apiKey, apiSecret, callback);
+                consumer.Proxy = proxy;
             }
             if (token != null && secret != null) {
                 accessToken = new RestClient(this.protocol + "://" + this.subdomainName + "." + this.uservoiceDomain);
                 accessToken.Authenticator = OAuth1Authenticator.ForAccessToken(apiKey, apiSecret, token, secret);
+                accessToken.Proxy = proxy;
             }
         }
         private RestClient getToken() {


### PR DESCRIPTION
Currently, the client does not appear to expose any settings for proxy environments. As a result, this means that communication with UserVoice within such an environment does not always work (for example, where outbound internet access is prohibited unless going through the proxy).

RestSharp does have proxy settings available, however the Client class is not currently exposing these. I propose exposing the relevant proxy properties from the RestSharp client class so that proxy connection settings can be configured as required.
